### PR TITLE
Make the environment to close itself

### DIFF
--- a/donkey_gym/envs/donkey_env.py
+++ b/donkey_gym/envs/donkey_env.py
@@ -87,6 +87,8 @@ class DonkeyEnv(gym.Env):
         # wait until loaded
         self.viewer.wait_until_loaded()
 
+    def __del__(self):
+        self.close()
 
     def close(self):
         self.proc.quit()


### PR DESCRIPTION
Avoid to call `env.close()` explicitly and call it on the deletion of the `env` object.